### PR TITLE
Javadoc fixes

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -27,7 +27,7 @@
 
     <groupId>jakarta.enterprise.deploy</groupId>
     <artifactId>jakarta.enterprise.deploy-api</artifactId>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.3-SNAPSHOT</version>
 
     <properties>
         <extension.name>javax.enterprise.deploy</extension.name>
@@ -193,9 +193,27 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.8</version>
+                <version>3.1.0</version>
                 <configuration>
+                    <source>8</source>
                     <additionalparam>-Xdoclint:none</additionalparam>
+                    <doctitle>Jakarta Deployment ${project.version} API</doctitle>
+                    <sourceFileExcludes>
+                        <sourceFileExclude>**/module-info.java</sourceFileExclude>
+                        <sourceFileExclude>target/**/*.java</sourceFileExclude>
+                    </sourceFileExcludes>
+                    <docfilessubdirs>true</docfilessubdirs>
+                    <links>
+                        <link>http://docs.oracle.com/javase/8/docs/api/</link>
+                    </links>
+                    <detectJavaApiLink>false</detectJavaApiLink>
+                    <detectOfflineLinks>false</detectOfflineLinks>
+                    <header><![CDATA[<br>Jakarta Deployment API v${project.version}]]>
+                    </header>
+                    <bottom><![CDATA[
+                    Copyright &#169; {inceptionYear}&#x2013;{currentYear} Oracle and/or its affiliates. All rights reserved.<br>
+                    Use is subject to <a href="{@docRoot}/doc-files/EFSL.html" target="_top">license terms</a>.]]>
+                    </bottom>
                 </configuration>
                 <executions>
                     <execution>

--- a/api/pom.xml
+++ b/api/pom.xml
@@ -28,6 +28,7 @@
     <groupId>jakarta.enterprise.deploy</groupId>
     <artifactId>jakarta.enterprise.deploy-api</artifactId>
     <version>1.7.3-SNAPSHOT</version>
+    <inceptionYear>2002</inceptionYear>
 
     <properties>
         <extension.name>javax.enterprise.deploy</extension.name>

--- a/api/src/main/java/javax/enterprise/deploy/model/DDBean.java
+++ b/api/src/main/java/javax/enterprise/deploy/model/DDBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,59 +17,59 @@
 package javax.enterprise.deploy.model;
 
 /**
- * An interface for beans that represent a fragment of a 
- * standard deployment descriptor.  A link is provided to 
+ * An interface for beans that represent a fragment of a
+ * standard deployment descriptor.  A link is provided to
  * the Jakarta EE application that includes this bean.
  */
-public interface DDBean 
+public interface DDBean
 {
-    
+
     /**
      * Returns the original xpath string provided by the DConfigBean.
      * @return The XPath of this Bean.
-     */    
+     */
     public String getXpath();
-    
+
     /**
      * Returns the XML text for by this bean.
      * @return The XML text for this Bean.
-     */    
+     */
 	public String getText();
 
     /**
-     * Returns a tool-specific reference for attribute ID on an 
-     * element in the deployment descriptor.  This attribute is 
+     * Returns a tool-specific reference for attribute ID on an
+     * element in the deployment descriptor.  This attribute is
      * defined for J2EE 1.2 and 1.3 components.
      * @return The XML text for this Bean or 'null' if
      *            no attribute was specifed with the tag.
-     */    
+     */
 	public String getId();
-   
+
    /**
     * Return the root element for this DDBean.
     * @return The DDBeanRoot at the root of this DDBean
     * tree.
-    */   
+    */
    public DDBeanRoot getRoot();
-      
+
    /**
     * Return a list of DDBeans based upon the XPath.
     * @param xpath An XPath string referring to a location in the
     * same deployment descriptor as this standard bean.
     * @return a list of DDBeans or 'null' if no matching XML data is
-    *            found. 
-    */   
+    *            found.
+    */
    public DDBean[] getChildBean(String xpath);
-   
+
    /**
     * Return a list of text values for a given XPath in the
     * deployment descriptor.
     * @param xpath An XPath.
     * @return The list text values for this XPath or 'null'
     *     if no matching XML data is found.
-    */   
+    */
    public String[] getText(String xpath);
-   
+
    /**
     * Register a listener for a specific XPath.
     *
@@ -87,20 +87,20 @@ public interface DDBean
     */
    public void removeXpathListener(String xpath, XpathListener xpl);
 
-    /** 
-     * Returns the list of attribute names associated with the XML element. 
+    /**
+     * Returns the list of attribute names associated with the XML element.
      *
-     * @return a list of attribute names on this element.  Null 
-     * is returned if there are no attributes. 
-     */ 
-   public String[] getAttributeNames(); 
+     * @return a list of attribute names on this element.  Null
+     * is returned if there are no attributes.
+     */
+   public String[] getAttributeNames();
 
     /**
-     * Returns the string value of the named attribute. 
+     * Returns the string value of the named attribute.
      *
-     * @return a the value of the attribute.  Null is returned 
-     * if there is no such attribute. 
-     */ 
-   public String getAttributeValue(String attrName); 
+     * @param attrName the attribute name
+     * @return a the value of the attribute.  Null is returned
+     * if there is no such attribute.
+     */
+   public String getAttributeValue(String attrName);
 }
-

--- a/api/src/main/java/javax/enterprise/deploy/model/DeployableObject.java
+++ b/api/src/main/java/javax/enterprise/deploy/model/DeployableObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,12 +17,12 @@
 package javax.enterprise.deploy.model;
 
 import javax.enterprise.deploy.shared.ModuleType;
-import java.util.Enumeration; 
-import java.io.InputStream; 
+import java.util.Enumeration;
+import java.io.InputStream;
 import java.io.IOException;
 
 /**
- * The DeployableObject interface is an abstract representation 
+ * The DeployableObject interface is an abstract representation
  * of a Jakarta EE deployable module (JAR, WAR, RAR, EAR). A
  * DeployableObject provides access to the module's deployment
  * descriptor and class files.
@@ -30,23 +30,23 @@ import java.io.IOException;
  * @author gfink
  * @version 0.1
  */
-public interface DeployableObject 
+public interface DeployableObject
 {
 
    /**
-    * Return the ModuleType of deployment descriptor (i.e., EAR, 
+    * Return the ModuleType of deployment descriptor (i.e., EAR,
     * JAR, WAR, RAR) this deployable object represents.
     * Values are found in DeploymentManager.
     *
     * @return The ModuleType of deployable object
-    */   
+    */
    public ModuleType getType();
-   
+
    /**
     * Return the top level standard bean representing
     * the root of the deployment descriptor.
     *
-    * @return A standard bean representing the deployment 
+    * @return A standard bean representing the deployment
     *         descriptor.
     */
     public DDBeanRoot getDDBeanRoot();
@@ -59,9 +59,9 @@ public interface DeployableObject
      *              be extracted from the deployment descriptor.
      * @return a array of DDBeans or 'null' if no matching data found.
      *
-     */   
+     */
    public DDBean[] getChildBean(String xpath);
-   
+
    /**
     * Return the XML content associated with the  XPath
     * from a deployment descriptor.
@@ -69,20 +69,20 @@ public interface DeployableObject
     * @param xpath An xpath string referring to a location in the
     *          deployment descriptor
     * @return a list XML content or 'null' if no matching data found.
-    */   
+    */
    public String[] getText(String xpath);
-   
-    /** 
+
+    /**
      * Retrieve the specified class from this deployable module.
      * <p>
      * One use: to get all finder methods from an EJB
      *
-     * If the tool is attempting to package an module 
+     * If the tool is attempting to package an module
      * and retrieve a class from the package, the class
-     * request may fail.  The class may not yet be 
+     * request may fail.  The class may not yet be
      * available.  The tool should respect the manifest
      * cross-path entries.
-     *  
+     *
      * @param className Class to retrieve.
      * @return Class representation of the class
      */
@@ -93,37 +93,36 @@ public interface DeployableObject
     * DOCTYPE text provided in every standard Java EE module's
     * deployment descriptor file.
     * @return a string containing the DTD version number
-    * 
+    *
 	* <PRE>
     * A module's deployment descriptor file always contains
-	* a document type identifier, DOCTYPE.  The DOCTYPE statement 
-	* contains the module DTD version number in the label of the 
+	* a document type identifier, DOCTYPE.  The DOCTYPE statement
+	* contains the module DTD version number in the label of the
 	* statement.
 	*
 	* 	The format of the DOCTYPE statement is:
-	*<ul>
-	*	&lt;!DOCTYPE root_element PUBLIC 
+    *
+	*	&lt;!DOCTYPE root_element PUBLIC
 	*	"-//organization//label//language" "location"&gt;
-	*</ul>
 	*
 	* root_element - is the name of the root document in the DTD.
-	* organization  - is the name of the organization responsible 
-	*                 for the creation and maintenance of the DTD 
+	* organization  - is the name of the organization responsible
+	*                 for the creation and maintenance of the DTD
 	*                 being referenced.
-	* label - is a unique descriptive name for the public text being 
-	*                 referenced.  
-	* language - is the ISO 639 language id representing the natural 
+	* label - is a unique descriptive name for the public text being
+	*                 referenced.
+	* language - is the ISO 639 language id representing the natural
 	*                 language encoding of th DTD.
 	* location - is the URL of the DTD.
 	*
 	* An example Java EE deployment descriptor DOCTYPE statement is:
-	*<ul>
+	*
 	*   &lt;!DOCTYPE application-client PUBLIC
     *   "-//Sun Microsystems, Inc.//DTD J2EE Application Client 1.3//EN"
     *   "http://java.sun.com/dtd/application-client_1_3.dtd"&gt;
-	*</ul>
-	* In this example the label is, "DTD J2EE Application Client 1.3", 
-	* and the DTD version number is 1.3. A call to getModuleDTDVersion 
+	*
+	* In this example the label is, "DTD J2EE Application Client 1.3",
+	* and the DTD version number is 1.3. A call to getModuleDTDVersion
 	* would return a string containing, "1.3".
 	* </PRE>
     *
@@ -131,43 +130,42 @@ public interface DeployableObject
     * deployment descritors in components for J2EE 1.4 this method is
     * being replaced by DDBeanRoot.getDDBeanRootVersion.
     *
-    * @deprecated As of version 1.1 replaced by 
-    *  DDBeanRoot.getDDBeanRootVersion() 
-    */   
+    * @deprecated As of version 1.1 replaced by
+    *  DDBeanRoot.getDDBeanRootVersion()
+    */
    public String getModuleDTDVersion();
 
     /**
-     * Returns a DDBeanRoot object for the XML instance document named.  
-     * This method should be used to return DDBeanRoot objects for non 
+     * Returns a DDBeanRoot object for the XML instance document named.
+     * This method should be used to return DDBeanRoot objects for non
      * deployment descriptor XML instance documents such as WSDL files.
      *
-     * @return a DDBeanRoot object for the XML data. 
-     * @throws java.io.FileNotFoundException, if the named file can not 
-     *  be found 
-     * @throws javax.enterprise.deploy.model.exceptions.DDBeanCreateException 
-     *  if an error is encountered creating the DDBeanRoot object. 
-     */ 
-    public DDBeanRoot getDDBeanRoot(String filename) throws 
-         java.io.FileNotFoundException, 
-         javax.enterprise.deploy.model.exceptions.DDBeanCreateException; 
+     * @return a DDBeanRoot object for the XML data.
+     * @throws java.io.FileNotFoundException if the named file can not
+     *  be found
+     * @throws javax.enterprise.deploy.model.exceptions.DDBeanCreateException
+     *  if an error is encountered creating the DDBeanRoot object.
+     */
+    public DDBeanRoot getDDBeanRoot(String filename) throws
+         java.io.FileNotFoundException,
+         javax.enterprise.deploy.model.exceptions.DDBeanCreateException;
 
-    /** 
-     * Returns an enumeration of the module file entries.  All elements 
-     * in the enumeration are of type String.  Each String represents a 
-     * file name relative to the root of the module. 
-     * 
-     * @return an enumeration of the archive file entries. 
-     */ 
-    public Enumeration entries(); 
+    /**
+     * Returns an enumeration of the module file entries.  All elements
+     * in the enumeration are of type String.  Each String represents a
+     * file name relative to the root of the module.
+     *
+     * @return an enumeration of the archive file entries.
+     */
+    public Enumeration entries();
 
-    /** 
-     * Returns the InputStream for the given entry name 
-     * The file name must be relative to the root of the module. 
-     * 
-     * @param name the file name relative to the root of the module. 
-     * 
-     * @return the InputStream for the given entry name or null if not found. 
-     */ 
-    public InputStream getEntry(String name); 
+    /**
+     * Returns the InputStream for the given entry name
+     * The file name must be relative to the root of the module.
+     *
+     * @param name the file name relative to the root of the module.
+     *
+     * @return the InputStream for the given entry name or null if not found.
+     */
+    public InputStream getEntry(String name);
  }
-

--- a/api/src/main/java/javax/enterprise/deploy/shared/ActionType.java
+++ b/api/src/main/java/javax/enterprise/deploy/shared/ActionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +22,7 @@ package javax.enterprise.deploy.shared;
  *
  * @author  rsearls
  */
-public class ActionType 
+public class ActionType
 {
 	private int value; // This enumeration value's int value
 
@@ -31,12 +31,12 @@ public class ActionType
 	 */
     public static final ActionType EXECUTE = new ActionType(0);
 	/**
-     * A cancel operation is being preformed on the DeploymentManager 
+     * A cancel operation is being preformed on the DeploymentManager
      * action command.
 	 */
     public static final ActionType CANCEL = new ActionType(1);
 	/**
-     * A stop operation is being preformed on the DeploymentManager 
+     * A stop operation is being preformed on the DeploymentManager
      * action command.
 	 */
     public static final ActionType STOP = new ActionType(2);
@@ -60,7 +60,7 @@ public class ActionType
      *
      * @param  value  Integer value.
      */
-    protected ActionType(int value) 
+    protected ActionType(int value)
     {   this.value = value;
     }
 
@@ -72,9 +72,11 @@ public class ActionType
     {   return value;
     }
 
-       
+
 	/**
-	 * Returns the string table for class ActionType
+	 * Returns the string table for class ActionType.
+	 *
+	 * @return the string table for class ActionType.
 	 */
 	protected String[] getStringTable()
 	{
@@ -83,6 +85,8 @@ public class ActionType
 
 	/**
 	 * Returns the enumeration value table for class ActionType
+	 *
+	 * @return the enumeration value table for class ActionType.
 	 */
 	protected ActionType[] getEnumValueTable()
 	{
@@ -91,7 +95,9 @@ public class ActionType
 
     /**
      * Return an object of the specified value.
+	 *
      * @param value a designator for the object.
+	 * @return an object of the specified value.
      */
     public static ActionType getActionType(int value)
     {   return enumValueTable[value];

--- a/api/src/main/java/javax/enterprise/deploy/shared/CommandType.java
+++ b/api/src/main/java/javax/enterprise/deploy/shared/CommandType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,7 +17,7 @@
 package javax.enterprise.deploy.shared;
 
 /**
- * Class CommandTypes defines enumeration values for the 
+ * Class CommandTypes defines enumeration values for the
  * DeploymentStatus object.
  *
  * @author  rsearls
@@ -64,17 +64,17 @@ public class CommandType
 	UNDEPLOY,
 	REDEPLOY,
 	};
-    
+
     /**
      * Construct a new enumeration value with the given integer value.
      *
      * @param  value  Integer value.
      */
-    protected CommandType(int value) 
+    protected CommandType(int value)
     {
 		this.value = value;
     }
-       
+
     /**
      * Returns this enumeration value's integer value.
      * @return the value
@@ -84,7 +84,9 @@ public class CommandType
     }
 
 	/**
-	 * Returns the string table for class CommandType
+	 * Returns the string table for class CommandType.
+	 *
+	 * @return the string table for class CommandType.
 	 */
 	protected String[] getStringTable()
 	{
@@ -92,7 +94,9 @@ public class CommandType
 	}
 
 	/**
-	 * Returns the enumeration value table for class CommandType
+	 * Returns the enumeration value table for class CommandType.
+	 *
+	 * @return the enumeration value table for class CommandType.
 	 */
 	protected CommandType[] getEnumValueTable()
 	{
@@ -101,7 +105,9 @@ public class CommandType
 
     /**
      * Return an object of the specified value.
+	 *
      * @param value a designator for the object.
+	 * @return an object of the specified value.
      */
     public static CommandType getCommandType(int value)
     {   return enumValueTable[value];

--- a/api/src/main/java/javax/enterprise/deploy/shared/DConfigBeanVersionType.java
+++ b/api/src/main/java/javax/enterprise/deploy/shared/DConfigBeanVersionType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,21 +22,21 @@ package javax.enterprise.deploy.shared;
  *
  * @author  rsearls
  */
-public class DConfigBeanVersionType 
+public class DConfigBeanVersionType
 {
 	private int value; // This enumeration value's int value
 
 	/**
      * J2EE Platform version 1.3
 	 */
-    public static final DConfigBeanVersionType V1_3 = 
+    public static final DConfigBeanVersionType V1_3 =
 		new DConfigBeanVersionType(0);
 
 	/**
      * J2EE Platform version 1.3.1
      * THIS CONSTANT SHOULD NEVER BE USED.  Use V1_3 instead.
 	 */
-    public static final DConfigBeanVersionType V1_3_1 = 
+    public static final DConfigBeanVersionType V1_3_1 =
 		new DConfigBeanVersionType(1);
 
     /**
@@ -71,7 +71,7 @@ public class DConfigBeanVersionType
      *
      * @param  value  Integer value.
      */
-    protected DConfigBeanVersionType(int value) 
+    protected DConfigBeanVersionType(int value)
     {   this.value = value;
     }
 
@@ -83,9 +83,11 @@ public class DConfigBeanVersionType
     {   return value;
     }
 
-       
+
 	/**
-	 * Returns the string table for class DConfigBeanVersionType
+	 * Returns the string table for class DConfigBeanVersionType.
+	 *
+	 * @return the string table for class DConfigBeanVersionType.
 	 */
 	protected String[] getStringTable()
 	{
@@ -93,7 +95,9 @@ public class DConfigBeanVersionType
 	}
 
 	/**
-	 * Returns the enumeration value table for class DConfigBeanVersionType
+	 * Returns the enumeration value table for class DConfigBeanVersionType.
+	 *
+	 * @return the enumeration value table for class DConfigBeanVersionType.
 	 */
 	protected DConfigBeanVersionType[] getEnumValueTable()
 	{
@@ -102,7 +106,9 @@ public class DConfigBeanVersionType
 
     /**
      * Return an object of the specified value.
+	 *
      * @param value a designator for the object.
+	 * @return an object of the specified value.
      */
     public static DConfigBeanVersionType getDConfigBeanVersionType(int value)
     {   return enumValueTable[value];

--- a/api/src/main/java/javax/enterprise/deploy/shared/ModuleType.java
+++ b/api/src/main/java/javax/enterprise/deploy/shared/ModuleType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,7 +22,7 @@ package javax.enterprise.deploy.shared;
  *
  * @author Rebecca Searls
  */
-public class ModuleType 
+public class ModuleType
 {
 	private int value; // This enumeration value's int value
 
@@ -74,7 +74,7 @@ public class ModuleType
 	".rar",
 	".war",
     };
-        
+
 
     /**
      * Construct a new enumeration value with the given integer value.
@@ -84,25 +84,29 @@ public class ModuleType
     protected ModuleType(int value)
     {   this.value = value;
     }
-        
+
     /**
      * Returns this enumeration value's integer value.
      * @return the value
      */
-    public int getValue() 
+    public int getValue()
 	{ 	return value;
     }
 
-        
+
 	/**
-	 * Returns the string table for class ModuleType
+	 * Returns the string table for class ModuleType.
+	 *
+	 * @return the string table for class ModuleType.
 	 */
 	protected String[] getStringTable()
 	{   return stringTable;
 	}
 
 	/**
-	 * Returns the enumeration value table for class ModuleType
+	 * Returns the enumeration value table for class ModuleType.
+	 *
+	 * @return the enumeration value table for class ModuleType.
 	 */
 	protected ModuleType[] getEnumValueTable()
 	{   return enumValueTable;
@@ -110,14 +114,18 @@ public class ModuleType
 
 	/**
      * Return the file extension string for this enumeration.
+	 *
+	 * @return the file extension string for this enumeration.
      */
     public String getModuleExtension()
     {   return (moduleExtension[getValue()]);
     }
-    
+
 	/**
      * Return an object of the specified value.
+	 *
      * @param value a designator for the object.
+	 * @return an object of the specified value.
      */
     public static ModuleType getModuleType(int value)
     {   return enumValueTable[value];
@@ -127,7 +135,7 @@ public class ModuleType
 	 * Return the string name of this ModuleType or the
 	 * integer value if outside the bounds of the table
 	 */
-    public String toString() 
+    public String toString()
 	{
     	String[] strTable = getStringTable();
     	int index = value - getOffset();
@@ -147,7 +155,7 @@ public class ModuleType
      * 0, override this method in the subclass.
      * @return the offset of the lowest enumeration value.
      */
-    protected int getOffset() 
+    protected int getOffset()
 	{ 	return 0;
     }
-} 
+}

--- a/api/src/main/java/javax/enterprise/deploy/shared/StateType.java
+++ b/api/src/main/java/javax/enterprise/deploy/shared/StateType.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -17,12 +17,12 @@
 package javax.enterprise.deploy.shared;
 
 /**
- * Class StateTypes defines enumeration values for the 
+ * Class StateTypes defines enumeration values for the
  * DeploymentStatus object.
  *
  * @author  rsearls
  */
-public class StateType 
+public class StateType
 {
 	private int value; // This enumeration value's int value
 
@@ -57,13 +57,13 @@ public class StateType
 	FAILED,
     RELEASED,
 	};
-    
+
     /**
      * Construct a new enumeration value with the given integer value.
      *
      * @param  value  Integer value.
      */
-    protected StateType(int value) 
+    protected StateType(int value)
     {   this.value = value;
     }
 
@@ -74,9 +74,11 @@ public class StateType
     public int getValue()
     {   return value;
     }
-       
+
 	/**
-	 * Returns the string table for class StateType
+	 * Returns the string table for class StateType.
+	 *
+	 * @return the string table for class StateType.
 	 */
 	protected String[] getStringTable()
 	{
@@ -84,7 +86,9 @@ public class StateType
 	}
 
 	/**
-	 * Returns the enumeration value table for class StateType
+	 * Returns the enumeration value table for class StateType.
+	 *
+	 * @return the enumeration value table for class StateType.
 	 */
 	protected StateType[] getEnumValueTable()
 	{
@@ -93,7 +97,9 @@ public class StateType
 
     /**
      * Return an object of the specified value.
+	 *
      * @param value a designator for the object.
+	 * @return an object of the specified value.
      */
     public static StateType getStateType(int value)
     {   return enumValueTable[value];

--- a/api/src/main/java/javax/enterprise/deploy/shared/factories/DeploymentFactoryManager.java
+++ b/api/src/main/java/javax/enterprise/deploy/shared/factories/DeploymentFactoryManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -33,33 +33,33 @@ import javax.enterprise.deploy.spi.factories.DeploymentFactory;
  * The DeploymentFactoryManager class is a central registry for
  * Jakarta EE DeploymentFactory objects.  The DeploymentFactoryManager
  * retains references to DeploymentFactory objects loaded by
- * a tool.  A DeploymentFactory object provides a reference to 
+ * a tool.  A DeploymentFactory object provides a reference to
  * a DeploymentManager.
  *
  * The DeploymentFactoryManager has been implemented as a singleton.
- * A tool gets a reference to the DeploymentFactoryManager via the 
+ * A tool gets a reference to the DeploymentFactoryManager via the
  * getInstance method.
  *
- * The DeploymentFactoryManager can return two types of 
- * DeploymentManagers, a connected DeploymentManager and a 
+ * The DeploymentFactoryManager can return two types of
+ * DeploymentManagers, a connected DeploymentManager and a
  * disconnected DeploymentManager.  The connected DeploymentManager
  * provides access to any product resources that may be required
  * for configurations and deployment.  The method to retrieve a
  * connected DeploymentManager is getDeploymentManager. This method
- * provides parameters for user name and password that the  product 
+ * provides parameters for user name and password that the  product
  * may require for user authentication.  A disconnected DeploymentManager
  * does not provide access to a running Jakarta EE product. The method
- * to retrieve a disconnected DeploymentManager is 
+ * to retrieve a disconnected DeploymentManager is
  * getDisconnectedDeploymentManager.  A disconnected DeploymentManager
  * does not need user authentication information.
  */
 public final class DeploymentFactoryManager {
-    
+
     private Vector deploymentFactories = null;
-    
+
     // Singleton instance
     private static DeploymentFactoryManager deploymentFactoryManager = new DeploymentFactoryManager();
-    
+
     /** Creates new RIDeploymentFactoryManager */
     private DeploymentFactoryManager() {
         deploymentFactories = new Vector();
@@ -72,25 +72,25 @@ public final class DeploymentFactoryManager {
     public static DeploymentFactoryManager getInstance() {
         return deploymentFactoryManager;
     }
-       
+
     /**
      * Retrieve the lists of currently registered DeploymentFactories.
      *
-     * @return the list of DeploymentFactory objects or an empty array 
+     * @return the list of DeploymentFactory objects or an empty array
      * 		if there are none.
      */
     public DeploymentFactory[] getDeploymentFactories() {
         Vector deploymentFactoriesSnapShot = null;
         synchronized(this){
-            deploymentFactoriesSnapShot = 
+            deploymentFactoriesSnapShot =
 				(Vector)this.deploymentFactories.clone();
         }
-        DeploymentFactory[] factoriesArray = 
+        DeploymentFactory[] factoriesArray =
 			new DeploymentFactory[deploymentFactoriesSnapShot.size()];
         deploymentFactoriesSnapShot.copyInto(factoriesArray);
         return factoriesArray;
     }
-    
+
     /**
      * Retrieves a DeploymentManager instance to use for deployment.
      * The caller provides a URI and optional username and password,
@@ -100,9 +100,9 @@ public final class DeploymentFactoryManager {
      * instance.
      *
      * @param uri The uri to check
-     * @param username An optional username (may be <tt>null</tt> if
+     * @param username An optional username (may be null if
      *        no authentication is required for this platform).
-     * @param password An optional password (may be <tt>null</yy> if
+     * @param password An optional password (may be null if
      *        no authentication is required for this platform).
      * @return A ready DeploymentManager instance.
      * @throws DeploymentManagerCreationException
@@ -114,7 +114,7 @@ public final class DeploymentFactoryManager {
 		 String password) throws DeploymentManagerCreationException{
         try{
             DeploymentFactory[] factories = this.getDeploymentFactories();
-            for(int factoryIndex=0; factoryIndex < factories.length; 
+            for(int factoryIndex=0; factoryIndex < factories.length;
 				factoryIndex++){
                 if(factories[factoryIndex].handlesURI(uri)){
                     return factories[factoryIndex].getDeploymentManager(uri,
@@ -129,29 +129,31 @@ public final class DeploymentFactoryManager {
 				"Could not get DeploymentManager");
         }
     }
-    
+
     /**
      * Registers a DeploymentFactory so it will be able to handle
      * requests.
+     *
+     * @param factory the deployment factory
      */
     public void registerDeploymentFactory(DeploymentFactory factory){
         this.deploymentFactories.add(factory);
     }
-    
+
     /**
-     * Return a <tt>disconnected</tt> DeploymentManager instance.
+     * Return a disconnected DeploymentManager instance.
      *
      * @param uri identifier of the disconnected DeploymentManager to
      *             return.
      * @return A DeploymentManager instance.
-     * @throws DeploymentDriverException  occurs if the DeploymentManager
+     * @throws DeploymentManagerCreationException  occurs if the DeploymentManager
      *         could not be created.
      */
-    public DeploymentManager getDisconnectedDeploymentManager(String uri) 
+    public DeploymentManager getDisconnectedDeploymentManager(String uri)
                throws DeploymentManagerCreationException {
         try{
             DeploymentFactory[] factories = this.getDeploymentFactories();
-            for(int factoryIndex=0; factoryIndex < factories.length; 
+            for(int factoryIndex=0; factoryIndex < factories.length;
 				factoryIndex++){
                 if(factories[factoryIndex].handlesURI(uri)){
                     return factories[factoryIndex].getDisconnectedDeploymentManager(uri);

--- a/api/src/main/java/javax/enterprise/deploy/spi/DeploymentConfiguration.java
+++ b/api/src/main/java/javax/enterprise/deploy/spi/DeploymentConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,17 +29,17 @@ import java.io.InputStream;
 import java.io.OutputStream;
 
 /**
- * An interface that defines a container for all the 
- * server-specific configuration information for a 
+ * An interface that defines a container for all the
+ * server-specific configuration information for a
  * single top-level Jakarta EE module.  The DeploymentConfiguration
- * object could represent a single stand alone module or an 
+ * object could represent a single stand alone module or an
  * EAR file that contains several sub-modules.
  *
  * @author gfink
  * @version 0.1
  */
 public interface DeploymentConfiguration {
-    
+
     /**
 	 * Returns an object that provides access to
      * the deployment descriptor data and classes
@@ -47,83 +47,83 @@ public interface DeploymentConfiguration {
      * @return DeployableObject
      */
     public DeployableObject getDeployableObject();
-        
+
     /**
      * Returns the top level configuration bean, DConfigBeanRoot,
      * associated with the deployment descriptor represented by
      * the designated DDBeanRoot bean.
      *
-     * @param bean The top level bean that represents the 
+     * @param bean The top level bean that represents the
      *       associated deployment descriptor.
-     * @return the DConfigBeanRoot for editing the server-specific 
+     * @return the DConfigBeanRoot for editing the server-specific
      *           properties required by the module.
-     * @throws ConfigurationException reports errors in generating 
+     * @throws ConfigurationException reports errors in generating
      *           a configuration bean
-     */    
-    public DConfigBeanRoot getDConfigBeanRoot(DDBeanRoot bean) 
+     */
+    public DConfigBeanRoot getDConfigBeanRoot(DDBeanRoot bean)
            throws ConfigurationException;
-    
+
     /**
      * Remove the root DConfigBean and all its children.
      *
      * @param bean the top leve DConfigBean to remove.
      * @throws BeanNotFoundException  the bean provides is
      *      not in this beans child list.
-     */    
+     */
 	public void removeDConfigBean(DConfigBeanRoot bean)
         throws BeanNotFoundException;
 
     /**
-	 * Restore from disk to instantated objects all the DConfigBeans 
+	 * Restore from disk to instantated objects all the DConfigBeans
      * associated with a specific deployment descriptor. The beans
      * may be fully or partially configured.
-     * @param inputArchive The input stream for the file from which the 
+     * @param inputArchive The input stream for the file from which the
      *         DConfigBeans should be restored.
-     * @param bean The DDBeanRoot bean associated with the 
+     * @param bean The DDBeanRoot bean associated with the
      *         deployment descriptor file.
      * @return The top most parent configuration bean, DConfigBeanRoot
-     * @throws ConfigurationException reports errors in generating 
+     * @throws ConfigurationException reports errors in generating
      *           a configuration bean
-     */    
-    public DConfigBeanRoot restoreDConfigBean(InputStream inputArchive, 
+     */
+    public DConfigBeanRoot restoreDConfigBean(InputStream inputArchive,
            DDBeanRoot bean) throws ConfigurationException;
-    
+
     /**
-     * Save to disk all the configuration beans associated with 
-     * a particular deployment descriptor file.  The saved data  
-     * may be fully or partially configured DConfigBeans. The 
+     * Save to disk all the configuration beans associated with
+     * a particular deployment descriptor file.  The saved data
+     * may be fully or partially configured DConfigBeans. The
      * output file format is recommended to be XML.
-     * @param outputArchive The output stream to which the DConfigBeans 
+     * @param outputArchive The output stream to which the DConfigBeans
      *        should be saved.
      * @param bean The top level bean, DConfigBeanRoot, from which to be save.
-     * @throws ConfigurationException reports errors in generating 
+     * @throws ConfigurationException reports errors in generating
      *           a configuration bean
-     */    
+     */
     public void saveDConfigBean(OutputStream outputArchive,DConfigBeanRoot bean)
             throws ConfigurationException;
-    
-    /** 
+
+    /**
 	 * Restore from disk to a full set of configuration beans previously
      * stored.
-     * @param inputArchive The input stream from which to restore 
+     * @param inputArchive The input stream from which to restore
      *       the Configuration.
-     * @throws ConfigurationException reports errors in generating 
+     * @throws ConfigurationException reports errors in generating
      *           a configuration bean
-     */    
-     public void restore(InputStream inputArchive) throws 
+     */
+     public void restore(InputStream inputArchive) throws
             ConfigurationException;
-    
-    /** 
+
+    /**
 	 * Save to disk the current set configuration beans created for
-     * this deployable module. 
+     * this deployable module.
      * It is recommended the file format be XML.
      *
-     * @param outputArchive The output stream to which to save the 
+     * @param outputArchive The output stream to which to save the
      *        Configuration.
-     * @throws ConfigurationException
-     */    
-    public void save(OutputStream outputArchive) throws 
+     * @throws ConfigurationException reports errors in generating
+     *           a configuration bean
+     */
+    public void save(OutputStream outputArchive) throws
             ConfigurationException;
-    
-}
 
+}

--- a/api/src/main/java/javax/enterprise/deploy/spi/DeploymentManager.java
+++ b/api/src/main/java/javax/enterprise/deploy/spi/DeploymentManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -35,7 +35,7 @@ import java.lang.Deprecated;
  * and vendor unique runtime configuration information.
  */
 public interface DeploymentManager {
-    
+
     /**
      * Retrieve the list of deployment targets supported by
      * this DeploymentManager.
@@ -47,8 +47,8 @@ public interface DeploymentManager {
      *           if there are none.
      */
     public Target[] getTargets() throws IllegalStateException;
-    
-    
+
+
     /**
      * Retrieve the list of Jakarta EE application modules distributed
      * to the identified targets and that are currently running
@@ -73,7 +73,7 @@ public interface DeploymentManager {
     public TargetModuleID[] getRunningModules(ModuleType moduleType,
             Target[] targetList) throws TargetException,
             IllegalStateException;
-    
+
     /**
      * Retrieve the list of Jakarta EE application modules distributed
      * to the identified targets and that are currently not
@@ -98,7 +98,7 @@ public interface DeploymentManager {
     public TargetModuleID[] getNonRunningModules(ModuleType moduleType,
             Target[] targetList) throws TargetException,
             IllegalStateException;
-    
+
     /**
      * Retrieve the list of all Jakarta EE application modules running
      * or not running on the identified targets.
@@ -122,21 +122,22 @@ public interface DeploymentManager {
     public TargetModuleID[] getAvailableModules(ModuleType moduleType,
             Target[] targetList) throws TargetException,
             IllegalStateException;
-    
+
     /**
      * Retrieve the object that provides server-specific deployment
      * configuration information for the Jakarta EE deployable component.
      *
      * @param dObj An object representing a Jakarta EE deployable component.
+     * @return the deployment configuration
      * @throws InvalidModuleException The DeployableObject is an
      *                      unknown or unsupport component for this
      *                      configuration tool.
      */
-    
+
     public DeploymentConfiguration createConfiguration(DeployableObject dObj)
     throws InvalidModuleException;
-    
-    
+
+
     /**
      * The distribute method performs three tasks; it validates the
      * deployment configuration data, generates all container specific
@@ -155,11 +156,11 @@ public interface DeploymentManager {
      * @return ProgressObject an object that tracks and reports the
      *                       status of the distribution process.
      */
-    
+
     public ProgressObject distribute(Target[] targetList,
             File moduleArchive, File deploymentPlan)
             throws IllegalStateException;
-    
+
     /**
      * The distribute method performs three tasks; it validates the
      * deployment configuration data, generates all container specific
@@ -179,11 +180,11 @@ public interface DeploymentManager {
      *                       status of the distribution process.
      * @deprecated as of Java EE 5, replaced with {@link #distribute(Target[], ModuleType, InputStream, InputStream)}
      */
-    
+
     public ProgressObject distribute(Target[] targetList,
             InputStream moduleArchive, InputStream deploymentPlan)
             throws IllegalStateException;
-    
+
     /**
      * The distribute method performs three tasks; it validates the
      * deployment configuration data, generates all container specific
@@ -204,11 +205,11 @@ public interface DeploymentManager {
      *                       status of the distribution process.
      *
      */
-    
+
     public ProgressObject distribute(Target[] targetList, ModuleType type,
             InputStream moduleArchive, InputStream deploymentPlan)
-            throws IllegalStateException;    
-    
+            throws IllegalStateException;
+
     /**
      * Start the application running.
      *
@@ -225,10 +226,10 @@ public interface DeploymentManager {
      * @return ProgressObject an object that tracks and reports the
      *                       status of the start operation.
      */
-    
+
     public ProgressObject start(TargetModuleID[] moduleIDList)
     throws IllegalStateException;
-    
+
     /**
      * Stop the application running.
      *
@@ -245,10 +246,10 @@ public interface DeploymentManager {
      * @return ProgressObject an object that tracks and reports the
      *                       status of the stop operation.
      */
-    
+
     public ProgressObject stop(TargetModuleID [] moduleIDList)
     throws IllegalStateException;
-    
+
     /**
      * Remove the application from the target server.
      *
@@ -266,10 +267,10 @@ public interface DeploymentManager {
      * @return ProgressObject an object that tracks and reports the
      *                       status of the stop operation.
      */
-    
+
     public ProgressObject undeploy(TargetModuleID[] moduleIDList)
     throws IllegalStateException;
-    
+
     /**
      * This method designates whether this platform vendor provides
      * application redeployment functionality. A value of true means
@@ -280,7 +281,7 @@ public interface DeploymentManager {
      *                   is not.
      */
     public boolean isRedeploySupported();
-    
+
     /**
      * (optional)
      * The redeploy method provides a means for updating currently
@@ -316,12 +317,12 @@ public interface DeploymentManager {
      * @throws java.lang.UnsupportedOperationException this optional command
      *         is not supported by this implementation.
      */
-    
+
     public ProgressObject redeploy(TargetModuleID[] moduleIDList,
             File moduleArchive, File deploymentPlan)
             throws java.lang.UnsupportedOperationException,
             IllegalStateException;
-    
+
     /**
      * (optional)
      * The redeploy method provides a means for updating currently
@@ -358,14 +359,14 @@ public interface DeploymentManager {
      * @throws java.lang.UnsupportedOperationException this optional command
      *         is not supported by this implementation.
      */
-    
+
     public ProgressObject redeploy(TargetModuleID[] moduleIDList,
             InputStream moduleArchive, InputStream deploymentPlan)
             throws java.lang.UnsupportedOperationException,
             IllegalStateException;
-    
-    
-    
+
+
+
     /**
      * The release method is the mechanism by which the tool signals
      * to the DeploymentManager that the tool does not need it to
@@ -384,9 +385,9 @@ public interface DeploymentManager {
      * the ProgressObject).
      *
      */
-    
+
     public void release();
-    
+
     /**
      * Returns the default locale supported by this implementation of
      * javax.enterprise.deploy.spi subpackages.
@@ -394,7 +395,7 @@ public interface DeploymentManager {
      * @return Locale the default locale for this implementation.
      */
     public Locale getDefaultLocale();
-    
+
     /**
      * Returns the active locale this implementation of
      * javax.enterprise.deploy.spi subpackages is running.
@@ -402,32 +403,34 @@ public interface DeploymentManager {
      * @return Locale the active locale of this implementation.
      */
     public Locale getCurrentLocale();
-    
+
     /**
      * Set the active locale for this implementation of
      * javax.enterprise.deploy.spi subpackages to run.
      *
+     * @param locale the locale to set
      * @throws java.lang.UnsupportedOperationException the provide locale is
      *      not supported.
      */
     public void setLocale(Locale locale)
         throws java.lang.UnsupportedOperationException;
-    
+
     /**
      * Returns an array of supported locales for this implementation.
      *
      * @return Locale[] the list of supported locales.
      */
     public Locale[] getSupportedLocales();
-    
+
     /**
      * Reports if this implementation supports the designated locale.
      *
+     * @param locale the locale to check
      * @return  A value of 'true' means it is support and 'false' it is
      *      not.
      */
     public boolean isLocaleSupported(Locale locale);
-    
+
     /**
      * Returns the Jakarta EE platform version number for which the
      * configuration beans are provided.  The beans must have
@@ -438,7 +441,7 @@ public interface DeploymentManager {
      * platform version number for which these beans are provided.
      */
     public DConfigBeanVersionType getDConfigBeanVersion();
-    
+
     /**
      * Returns 'true' if the configuration beans support the Jakarta EE platform
      * version specified.  It returns 'false' if the version is
@@ -449,7 +452,7 @@ public interface DeploymentManager {
      * @return 'true' if the version is supported and 'false if not.
      */
     public boolean isDConfigBeanVersionSupported(DConfigBeanVersionType version);
-    
+
     /**
      * Set the configuration beans to be used to the Jakarta EE platform
      * version specificed.

--- a/api/src/main/java/javax/enterprise/deploy/spi/Target.java
+++ b/api/src/main/java/javax/enterprise/deploy/spi/Target.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -21,19 +21,23 @@ package javax.enterprise.deploy.spi;
  * A Target interface represents a single logical
  * core server of one instance of a Jakarta EE platform
  * product.  It is a designator for a server and
- * the implied location to copy a configured 
+ * the implied location to copy a configured
  * application for the server to access.
  */
 public interface Target
 {
    /**
     * Retrieve the name of the target server.
+    *
+    * @return the name
     */
    public String getName();
 
    /**
     * Retrieve other descriptive information
     * about the target.
+    *
+    * @return the description
     */
    public String getDescription();
 }

--- a/api/src/main/java/javax/enterprise/deploy/spi/TargetModuleID.java
+++ b/api/src/main/java/javax/enterprise/deploy/spi/TargetModuleID.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -18,13 +18,13 @@ package javax.enterprise.deploy.spi;
 
 /**
  * A TargetModuleID interface represents a unique
- * identifier for a deployed application module. 
- * A deployable application module can be an EAR, 
- * JAR, WAR or RAR file.  
+ * identifier for a deployed application module.
+ * A deployable application module can be an EAR,
+ * JAR, WAR or RAR file.
  *
- * A TargetModuleID can represent a root module or 
- * a child module.  A root module TargetModuleID 
- * has no parent.  It represents a deployed EAR 
+ * A TargetModuleID can represent a root module or
+ * a child module.  A root module TargetModuleID
+ * has no parent.  It represents a deployed EAR
  * file or stand alone module.  A child module
  * TargetModuleID represents a deployed sub module
  * of a Jakarta EE application.
@@ -35,7 +35,7 @@ package javax.enterprise.deploy.spi;
  *
  * The identifier consists of the target name
  * and the unique identifier for the deployed
- * application module. 
+ * application module.
  */
 public interface TargetModuleID
 {
@@ -51,6 +51,8 @@ public interface TargetModuleID
    /**
     * Retrieve the id assigned to represent
     * the deployed module.
+    *
+    * @return the id assigned to represent the deployed module
     */
    public String getModuleID();
 
@@ -58,7 +60,7 @@ public interface TargetModuleID
    /**
     * If this TargetModulID represents a web
     * module retrieve the URL for it.
-    * 
+    *
     * @return the URL of a web module or null
     *         if the module is not a web module.
     */
@@ -74,8 +76,8 @@ public interface TargetModuleID
     * Retrieve the identifier of the parent
     * object of this deployed module. If there
     * is no parent then this is the root object
-    * deployed.  The root could represent an EAR 
-    * file or it could be a stand alone module 
+    * deployed.  The root could represent an EAR
+    * file or it could be a stand alone module
     * that was deployed.
     *
     * @return the TargetModuleID of the parent
@@ -89,7 +91,7 @@ public interface TargetModuleID
     * Retrieve a list of identifiers of the children
     * of this deployed module.
     *
-    * @return a list of TargetModuleIDs identifying the 
+    * @return a list of TargetModuleIDs identifying the
     *         childern of this object. A <code>null</code>
     *         value means this module has no childern
     */

--- a/api/src/main/java/javax/enterprise/deploy/spi/factories/DeploymentFactory.java
+++ b/api/src/main/java/javax/enterprise/deploy/spi/factories/DeploymentFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -20,12 +20,12 @@ import javax.enterprise.deploy.spi.DeploymentManager;
 import javax.enterprise.deploy.spi.exceptions.DeploymentManagerCreationException;
 
 /**
- * The DeploymentFactory interface is a deployment driver for a    
+ * The DeploymentFactory interface is a deployment driver for a
  * Jakarta EE plaform product.  It returns a DeploymentManager object
  * which represents a connection to a specific Jakarta EE platform
  * product.
  *
- * <p> Each application server vendor must provide an implementation 
+ * <p> Each application server vendor must provide an implementation
  *  of this class in order for the Jakarta Deployment to work
  *  with their product.
  *
@@ -35,52 +35,52 @@ import javax.enterprise.deploy.spi.exceptions.DeploymentManagerCreationException
  * not required that the class have a static initializer that registers
  * an instance of the class with the DeploymentFactoryManager class.
  *
- * <p> A <tt>connected</tt> or <tt>disconnected</tt> DeploymentManager 
- * can be requested.  A DeploymentManager that runs connected to the 
+ * <p> A connected or disconnected DeploymentManager
+ * can be requested.  A DeploymentManager that runs connected to the
  * platform can provide access to Jakarta EE resources. A DeploymentManager
- * that runs disconnected only provides module deployment configuration 
- * support. 
+ * that runs disconnected only provides module deployment configuration
+ * support.
  *
  * @see javax.enterprise.deploy.shared.factories.DeploymentFactoryManager
  */
-public interface DeploymentFactory 
+public interface DeploymentFactory
 {
     /**
      * Tests whether this factory can create a DeploymentManager
      * object based on the specificed URI.  This does not indicate
      * whether such an attempt will be successful, only whether the
-     * factory can handle the uri. 
+     * factory can handle the uri.
      * @param uri The uri to check
-     * @return <tt>true</tt> if the factory can handle the uri.
+     * @return true if the factory can handle the uri.
      */
     public boolean handlesURI(String uri);
 
     /**
-     * Return a <tt>connected</tt> DeploymentManager instance.
+     * Return a connected DeploymentManager instance.
      *
      * @param uri The URI that specifies the connection parameters
-     * @param username An optional username (may be <tt>null</tt> if
+     * @param username An optional username (may be null if
      *        no authentication is required for this platform).
-     * @param password An optional password (may be <tt>null</yy> if
+     * @param password An optional password (may be null if
      *        no authentication is required for this platform).
      * @return A ready DeploymentManager instance.
-     * @throws DeploymentManagerCreationException  occurs when a 
-     *        DeploymentManager could not be returned (server down, 
+     * @throws DeploymentManagerCreationException  occurs when a
+     *        DeploymentManager could not be returned (server down,
      *        unable to authenticate, etc).
      */
-    public DeploymentManager getDeploymentManager(String uri, 
-            String username, String password) 
+    public DeploymentManager getDeploymentManager(String uri,
+            String username, String password)
             throws DeploymentManagerCreationException;
 
     /**
-     * Return a <tt>disconnected</tt> DeploymentManager instance. 
+     * Return a disconnected DeploymentManager instance.
      *
      * @param uri the uri of the DeploymentManager to return.
-     * @return A DeploymentManager <tt>disconnected</tt> instance.
-     * @throws DeploymentManagerCreationException occurs if the 
+     * @return A DeploymentManager disconnected instance.
+     * @throws DeploymentManagerCreationException occurs if the
      *         DeploymentManager could not be created.
      */
-    public DeploymentManager getDisconnectedDeploymentManager(String uri) 
+    public DeploymentManager getDisconnectedDeploymentManager(String uri)
             throws DeploymentManagerCreationException;
 
     /**
@@ -90,7 +90,7 @@ public interface DeploymentFactory
     public String getDisplayName();
 
     /**
-     * Provide a string identifying version of this vendor's 
+     * Provide a string identifying version of this vendor's
      * DeploymentManager.
      * @return the name of the vendor's DeploymentManager.
      */

--- a/api/src/main/java/javax/enterprise/deploy/spi/status/ProgressEvent.java
+++ b/api/src/main/java/javax/enterprise/deploy/spi/status/ProgressEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -23,7 +23,7 @@ import java.util.EventObject;
  * An event which indicates that a deployment
  * status change has occurred.
  *
- * @see ProgressListener 
+ * @see ProgressListener
  * @see ProgressObject
  */
 public class ProgressEvent extends EventObject
@@ -36,7 +36,8 @@ public class ProgressEvent extends EventObject
     * progress event.
     *
     * @param source the object on which the Event initially occurred.
-    * @param sCode  the object containing the status 
+    * @param targetModuleID target module ID
+    * @param sCode  the object containing the status
     *               information.
     */
    public ProgressEvent (Object source, TargetModuleID targetModuleID,
@@ -51,7 +52,7 @@ public class ProgressEvent extends EventObject
     * Retrieve the TargetModuleID for this event
     *
     * @return the object containing the TargetModuleID
-    */ 
+    */
    public TargetModuleID getTargetModuleID()
    {
      return targetModuleID;

--- a/api/src/main/java/javax/enterprise/deploy/spi/status/ProgressObject.java
+++ b/api/src/main/java/javax/enterprise/deploy/spi/status/ProgressObject.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1997, 2018 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1997, 2019 Oracle and/or its affiliates. All rights reserved.
  *
  * This program and the accompanying materials are made available under the
  * terms of the Eclipse Public License v. 2.0, which is available at
@@ -22,10 +22,10 @@ import javax.enterprise.deploy.spi.exceptions.OperationUnsupportedException;
 /**
  * The ProgressObject interface tracks and reports
  * the progress of the deployment activities,
- * distribute, start, stop, undeploy.  
+ * distribute, start, stop, undeploy.
  *
- * <p>This class has an <code> optional</code> cancel 
- * method.  The support of the cancel function can 
+ * <p>This class has an <code> optional</code> cancel
+ * method.  The support of the cancel function can
  * be tested by the isCancelSupported method.
  * </p>
  *
@@ -49,7 +49,7 @@ public interface ProgressObject
    /**
     * Retrieve the list of TargetModuleIDs successfully
     * processed or created by the associated DeploymentManager
-    * operation. 
+    * operation.
     *
     * @return a list of TargetModuleIDs.
     */
@@ -60,14 +60,15 @@ public interface ProgressObject
     * Return the ClientConfiguration object associated with the
     * TargetModuleID.
     *
-    * @return ClientConfiguration for a given TargetModuleID or 
+    * @param id target module ID
+    * @return ClientConfiguration for a given TargetModuleID or
     *         null if none exists.
     */
-    public ClientConfiguration getClientConfiguration(TargetModuleID id); 
+    public ClientConfiguration getClientConfiguration(TargetModuleID id);
 
 
    /**
-    * Tests whether the vendor supports a cancel 
+    * Tests whether the vendor supports a cancel
     * opertation for deployment activities.
     *
     * @return <code>true</code> if canceling an
@@ -77,10 +78,10 @@ public interface ProgressObject
 
    /**
     * (optional)
-    * A cancel request on an in-process operation 
+    * A cancel request on an in-process operation
     * stops all further processing of the operation and returns
     * the environment to it original state before the operation
-    * was executed.  An operation that has run to completion 
+    * was executed.  An operation that has run to completion
     * cannot be cancelled.
     *
     * @throws OperationUnsupportedException this optional command
@@ -99,10 +100,10 @@ public interface ProgressObject
 
    /**
     * (optional)
-    * A stop request on an in-process operation allows the 
-    * operation on the current TargetModuleID to run to completion but 
-    * does not process any of the remaining unprocessed TargetModuleID 
-    * objects.  The processed TargetModuleIDs must be returned by the 
+    * A stop request on an in-process operation allows the
+    * operation on the current TargetModuleID to run to completion but
+    * does not process any of the remaining unprocessed TargetModuleID
+    * objects.  The processed TargetModuleIDs must be returned by the
     * method getResultTargetModuleIDs.
     *
     * @throws OperationUnsupportedException this optional command
@@ -115,7 +116,7 @@ public interface ProgressObject
     * actions.
     *
     * @param pol the listener to receive events
-    * @see ProgressEvent 
+    * @see ProgressEvent
     */
    public void addProgressListener(ProgressListener pol);
 
@@ -123,7 +124,7 @@ public interface ProgressObject
     * Remove a ProgressObject listener.
     *
     * @param pol the listener being removed
-    * @see ProgressEvent 
+    * @see ProgressEvent
     */
    public void removeProgressListener(ProgressListener pol);
 }

--- a/api/src/main/javadoc/doc-files/EFSL.html
+++ b/api/src/main/javadoc/doc-files/EFSL.html
@@ -1,0 +1,72 @@
+<html>
+<head>
+<title>Eclipse Foundation Specification License - v1.0</title>
+</head>
+<body>
+<h1>Eclipse Foundation Specification License - v1.0</h1>
+<p>By using and/or copying this document, or the Eclipse Foundation
+  document from which this statement is linked, you (the licensee) agree
+  that you have read, understood, and will comply with the following
+  terms and conditions:</p>
+
+<p>Permission to copy, and distribute the contents of this document, or
+  the Eclipse Foundation document from which this statement is linked, in
+  any medium for any purpose and without fee or royalty is hereby
+  granted, provided that you include the following on ALL copies of the
+  document, or portions thereof, that you use:</p>
+
+<ul>
+  <li> link or URL to the original Eclipse Foundation document.</li>
+  <li>All existing copyright notices, or if one does not exist, a notice
+      (hypertext is preferred, but a textual representation is permitted)
+      of the form: &quot;Copyright &copy; [$date-of-document]
+      &ldquo;Eclipse Foundation, Inc. &lt;&lt;url to this license&gt;&gt;
+      &quot;
+  </li>
+</ul>
+
+<p>Inclusion of the full text of this NOTICE must be provided. We
+  request that authorship attribution be provided in any software,
+  documents, or other items or products that you create pursuant to the
+  implementation of the contents of this document, or any portion
+  thereof.</p>
+
+<p>No right to create modifications or derivatives of Eclipse Foundation
+  documents is granted pursuant to this license, except anyone may
+  prepare and distribute derivative works and portions of this document
+  in software that implements the specification, in supporting materials
+  accompanying such software, and in documentation of such software,
+  PROVIDED that all such works include the notice below. HOWEVER, the
+  publication of derivative works of this document for use as a technical
+  specification is expressly prohibited.</p>
+
+<p>The notice is:</p>
+
+<p>&quot;Copyright &copy; 2018 Eclipse Foundation. This software or
+  document includes material copied from or derived from [title and URI
+  of the Eclipse Foundation specification document].&quot;</p>
+
+<h2>Disclaimers</h2>
+
+<p>THIS DOCUMENT IS PROVIDED &quot;AS IS,&quot; AND THE COPYRIGHT
+  HOLDERS AND THE ECLIPSE FOUNDATION MAKE NO REPRESENTATIONS OR
+  WARRANTIES, EXPRESS OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+  WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE,
+  NON-INFRINGEMENT, OR TITLE; THAT THE CONTENTS OF THE DOCUMENT ARE
+  SUITABLE FOR ANY PURPOSE; NOR THAT THE IMPLEMENTATION OF SUCH CONTENTS
+  WILL NOT INFRINGE ANY THIRD PARTY PATENTS, COPYRIGHTS, TRADEMARKS OR
+  OTHER RIGHTS.</p>
+
+<p>THE COPYRIGHT HOLDERS AND THE ECLIPSE FOUNDATION WILL NOT BE LIABLE
+  FOR ANY DIRECT, INDIRECT, SPECIAL OR CONSEQUENTIAL DAMAGES ARISING OUT
+  OF ANY USE OF THE DOCUMENT OR THE PERFORMANCE OR IMPLEMENTATION OF THE
+  CONTENTS THEREOF.</p>
+
+<p>The name and trademarks of the copyright holders or the Eclipse
+  Foundation may NOT be used in advertising or publicity pertaining to
+  this document or its contents without specific, written prior
+  permission. Title to copyright in this document will at all times
+  remain with copyright holders.</p>
+
+</body>
+</html>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright (c) 2012, 2018 Oracle and/or its affiliates. All rights reserved.
+    Copyright (c) 2012, 2019 Oracle and/or its affiliates. All rights reserved.
 
     This program and the accompanying materials are made available under the
     terms of the Eclipse Public License v. 2.0, which is available at
@@ -29,7 +29,7 @@
     <groupId>org.eclipse.ee4j.enterprise.deploy-api</groupId>
     <artifactId>enterprise.deploy-api-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.7.1-SNAPSHOT</version>
+    <version>1.7.3-SNAPSHOT</version>
     <name>${extension.name} API</name>
     <description>Eclipse Project for Stable Jakarta EE APIs</description>
     <url>https://github.com/eclipse-ee4j/enterprise-deployment</url>
@@ -44,7 +44,7 @@
     <properties>
         <extension.name>javax.enterprise.deploy</extension.name>
         <spec.version>1.6</spec.version>
-        <bundle.symbolicName>javax.enterprise.deploy-api</bundle.symbolicName>         
+        <bundle.symbolicName>javax.enterprise.deploy-api</bundle.symbolicName>
         <vendor.name>Eclipse Project for Stable EE4J APIs</vendor.name>
         <implementation.vendor.id>org.glassfish</implementation.vendor.id>
         <findbugs.version>2.3.1</findbugs.version>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -25,7 +25,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>jakarta.enterprise.deploy</groupId>
     <artifactId>deployment-spec</artifactId>
-    <version>1.7-SNAPSHOT</version>
+    <version>1.8-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Jakarta Deployment Specification</name>
 


### PR DESCRIPTION
EFSL license added, maven-javadoc plugin version bumped to 3.1.0, fixed javadoc generation of Java 11

Signed-off-by: Dmitry Kornilov <dmitry.kornilov@oracle.com>